### PR TITLE
Update the Overcast app icon

### DIFF
--- a/overcast-sonos.py
+++ b/overcast-sonos.py
@@ -74,14 +74,14 @@ def getMetadata(id, index, count):
                 'title': 'All Active Episodes',
                 'itemType': 'container',
                 'canPlay': False,
-                'albumArtURI': 'http://is2.mzstatic.com/image/thumb/Purple62/v4/22/c7/93/22c793a7-55a8-e72b-756c-90641e7b96d4/source/175x175bb.jpg',
+                'albumArtURI': 'http://is3.mzstatic.com/image/thumb/Purple111/v4/20/5b/5e/205b5ef7-ee0e-7d0c-2d11-12f611c579f4/source/175x175bb.jpg',
             }},
             {'mediaCollection': {
                 'id': 'podcasts',
                 'title': 'Podcasts',
                 'itemType': 'container',
                 'canPlay': False,
-                'albumArtURI': 'http://is2.mzstatic.com/image/thumb/Purple62/v4/22/c7/93/22c793a7-55a8-e72b-756c-90641e7b96d4/source/175x175bb.jpg',
+                'albumArtURI': 'http://is3.mzstatic.com/image/thumb/Purple111/v4/20/5b/5e/205b5ef7-ee0e-7d0c-2d11-12f611c579f4/source/175x175bb.jpg',
             }},
         ]}
 


### PR DESCRIPTION
Updates the Overcast icon from with a current version the App store (it was refreshed in Overcast v3).

Fixes #8. 

cc @antonino-u 